### PR TITLE
Added Usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # alliance-bb-autologin
 This contains a python script which may be used to login to alliance broadband automatically
+
+## Usage
+1. Make sure that `Python 3` and `pip` is available in your system.
+2. Install the required Python packages by the command:
+    ```bash
+    pip install -r requirements.txt
+    ```
+3. Edit your login credentials in `autologin.py`. Then you can run the program using
+   ```bash
+   python3 autologin.py
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2020.12.5
+chardet==3.0.4
+idna==2.10
+lxml==4.6.2
+pyparsing==2.4.7
+requests==2.25.0
+twill==2.0.1
+urllib3==1.26.2


### PR DESCRIPTION
Generally it is a good practice to add Usage and Installation Instructions in README, so that new users can execute the code easily in their system.